### PR TITLE
Update Vimux API usage to new pubic methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # vimux-cargo
 
 Run [cargo](https://github.com/rust-lang/cargo) commands in vim and tmux using
-[vimux](https://github.com/benmills/vimux).
+[vimux](https://github.com/preservim/vimux).
 
 ## Usage
 

--- a/plugin/vimux-cargo.vim
+++ b/plugin/vimux-cargo.vim
@@ -25,7 +25,7 @@ function! CargoRun()
 endfunction
 
 function! CargoPromptArgs()
-  let l:args = input(_VimuxOption("g:VimuxPromptString", "Args? "))
+  let l:args = input(VimuxOption("VimuxPromptString"))
   call VimuxRunCommand("clear " . s:separator . " cargo run -- " . l:args)
 endfunction
 


### PR DESCRIPTION
The _VimuxOption method was a pseudo private API that should never have
been used — or rather in this case should never have been private. It is
now promoted to a regular public method. Additionally defaults are
handled in such a way that they don't need to be specified on every
possible use of an option.
